### PR TITLE
Add sample EC2 start/stop lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# test
+# EC2 起動/停止 Lambda
+
+このリポジトリには、入力イベントに応じて EC2 インスタンスを起動または停止するシンプルな AWS Lambda 関数が含まれています。
+
+## ファイル構成
+
+- `lambda/lambda_function.py` - `boto3` を利用した Lambda ハンドラー実装
+
+## 使い方
+
+1. `lambda` ディレクトリを ZIP 化するなどして Lambda 関数としてデプロイします（SAM など任意の方法で構いません）。
+2. 環境変数 `INSTANCE_IDS` に対象とする EC2 インスタンス ID をコンマ区切りで指定します。
+3. 関数実行時には以下のようなイベントを渡します。
+
+```json
+{ "action": "start" }
+```
+
+`action` には `start` または `stop` を指定できます。イベント側でインスタンス ID を上書きすることも可能です。
+
+```json
+{ "action": "stop", "instance_ids": ["i-12345678"] }
+```
+
+定期実行したい場合は CloudWatch Events や API Gateway などをトリガーとして利用してください。

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -1,0 +1,43 @@
+import os
+import logging
+import boto3
+from botocore.exceptions import ClientError
+
+ec2 = boto3.client('ec2')
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# 環境変数から対象インスタンス ID を取得（コンマ区切り）
+INSTANCE_IDS = [i.strip() for i in os.getenv('INSTANCE_IDS', '').split(',') if i.strip()]
+
+
+def lambda_handler(event, context):
+    """EC2 インスタンスを起動または停止する Lambda のエントリポイント。
+
+    イベント例:
+    {
+        "action": "start" | "stop",
+        "instance_ids": ["i-12345678", "i-87654321"]  # 任意。環境変数より優先
+    }
+    """
+    action = event.get('action', 'start').lower()
+    ids = event.get('instance_ids', INSTANCE_IDS)
+
+    if not ids:
+        logger.error('No instance IDs provided')
+        return {'status': 'error', 'message': 'No instance IDs provided'}
+
+    if action not in ('start', 'stop'):
+        logger.error('Invalid action: %s', action)
+        return {'status': 'error', 'message': f'Invalid action {action}'}
+
+    try:
+        if action == 'start':
+            ec2.start_instances(InstanceIds=ids)
+        else:
+            ec2.stop_instances(InstanceIds=ids)
+        logger.info('%s action executed for instances: %s', action, ids)
+        return {'status': 'success', 'action': action, 'instances': ids}
+    except ClientError as e:
+        logger.exception('Failed to %s instances %s: %s', action, ids, e)
+        return {'status': 'error', 'message': str(e)}


### PR DESCRIPTION
## Summary
- implement a simple AWS Lambda handler to start or stop EC2 instances
- document usage in README
- READMEとコード内コメントを日本語化

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f0b7d64c832ab2dd2cc57f8298f9